### PR TITLE
Fix str_pad direction

### DIFF
--- a/WindowsAzure/Blob/BlobRestProxy.php
+++ b/WindowsAzure/Blob/BlobRestProxy.php
@@ -1348,7 +1348,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
                     }
                 }
                 $block = new Block();
-                $block->setBlockId(base64_encode(str_pad($counter++, '0', 6)));
+                $block->setBlockId(base64_encode(str_pad($counter++, '0', 6, STR_PAD_LEFT)));
                 $block->setType('Uncommitted');
                 array_push($blockIds, $block);
                 $this->createBlobBlock($container, $blob, $block->getBlockId(), $body);


### PR DESCRIPTION
Without this fix, 
The 1, 10 and 100 blocks have the same identifier.
The upload complete but the destination file is corrupted
